### PR TITLE
fix: allow to work with yarn3

### DIFF
--- a/src/tarballs/build.ts
+++ b/src/tarballs/build.ts
@@ -57,7 +57,7 @@ export async function build(c: IConfig, options: {
     const yarn = await qq.exists([yarnRoot, 'yarn.lock'])
     if (yarn) {
       await qq.cp([yarnRoot, 'yarn.lock'], '.')
-      await qq.x('yarn --no-progress --production --non-interactive')
+      await qq.x('yarn --production --non-interactive')
     } else {
       let lockpath = qq.join(c.root, 'package-lock.json')
       if (!await qq.exists(lockpath)) {


### PR DESCRIPTION
`yarn install --no-progress` throws an error in yarn 3. Removing this flag.